### PR TITLE
Fixed issue when using with Greengrass

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 lib
+build

--- a/src/mgos_aws_shadow.c
+++ b/src/mgos_aws_shadow.c
@@ -522,7 +522,7 @@ bool mgos_aws_shadow_init(void) {
     return false;
   }
   const char *mqtt_server = mgos_sys_config_get_mqtt_server();
-  if (mqtt_server == NULL || strstr(mqtt_server, "amazonaws.com") == NULL) {
+  if (mqtt_server == NULL) {
     LOG(LL_ERROR, ("MQTT is not configured for AWS, not initialising shadow"));
     return false;
   }


### PR DESCRIPTION
Problem reported here: https://github.com/mongoose-os-libs/shadow/issues/1

One of the problems has been fixed use with AWS Greengrass, but we still need to fix the problem of event return: **???**.

I do not know if they will consider this a problem, but I will explain what happens:

If I call **Shadow.get()**, then an event with the number 0 is returned in case, I believe it is referring to this enum (MGOS_AWS_SHADOW_TOPIC_UNKNOWN).

Already if I call the **Shadow.update()**, the same happens but the enum (MGOS_AWS_SHADOW_TOPIC_GET) is returned.

Well that's it ... I'll be waiting!